### PR TITLE
New state changes for on_hold and trial_ended

### DIFF
--- a/subscription-states/subscription_states.dot
+++ b/subscription-states/subscription_states.dot
@@ -4,9 +4,9 @@ digraph subscription_states {
  trialing -> trial_ended;
  trialing -> past_due;
  trialing -> canceled;
- trialing > on_hold;
+ trialing -> on_hold;
  trial_ended -> canceled;
- trial_ended > active;
+ trial_ended -> active;
  active -> canceled;
  active -> past_due;
  active -> expired;

--- a/subscription-states/subscription_states.dot
+++ b/subscription-states/subscription_states.dot
@@ -4,7 +4,9 @@ digraph subscription_states {
  trialing -> trial_ended;
  trialing -> past_due;
  trialing -> canceled;
+ trialing > on_hold;
  trial_ended -> canceled;
+ trial_ended > active;
  active -> canceled;
  active -> past_due;
  active -> expired;
@@ -18,5 +20,6 @@ digraph subscription_states {
  canceled -> trialing;
  on_hold -> active;
  on_hold -> canceled;
+ on_hold -> trialing;
 }
 


### PR DESCRIPTION
You can now put trialing subscriptions on hold. Also, an older change is reactivating trial_ended subscriptions